### PR TITLE
add ssh-agent auth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+type Auth struct {
+
+}
+
+func sshAgentAuth() ssh.AuthMethod {
+	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
+		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
+	}
+	return nil
+}
+
+func PasswordCallback(user string) ssh.AuthMethod {
+	return ssh.PasswordCallback(func() (string, error) {
+		return easyPrompt(user)
+	})
+}

--- a/auth.go
+++ b/auth.go
@@ -8,10 +8,6 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-type Auth struct {
-
-}
-
 func sshAgentAuth() ssh.AuthMethod {
 	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
 		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)

--- a/main.go
+++ b/main.go
@@ -59,12 +59,7 @@ func main() {
 		color.Magenta("on hosts")
 		color.Yellow(fmt.Sprintf("%v", hosts))
 
-		pswd, err := prompt(args)
-		if err != nil {
-			dief("failed to read password: %v", err)
-		}
-
-		if err := runCmd(args.user, pswd, hosts, args.command, args.pw); err != nil {
+		if err := runCmd(args.user, hosts, args.command, args.pw); err != nil {
 			dief("failed to run command: %v", err)
 		}
 	}

--- a/password.go
+++ b/password.go
@@ -24,3 +24,12 @@ func prompt(args args) (string, error) {
 	}
 	return string(bs), nil
 }
+
+func easyPrompt(user string) (string, error) {
+	color.White("  password for '%s' --> ", user)
+	bs, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read password")
+	}
+	return string(bs), nil
+}


### PR DESCRIPTION
Instead of prompting for a password when executing runCmd, we
will instead use ssh-agent auth. If the SSH_AUTH_SOCK env
variable is empty, then we will use a PasswordCallback to prompt
for the password.

If we want to send the password via stdin to execute a command
with sudo we will still prompt for the password.

Because we're not attempting to detect if we _need_ to send a 
password by checking if a script has PASSWORD in it or if a 
command has "sudo" on it this change only really works on running
a command and not a script.