### PR TITLE
Detect sudo on scripts and commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 commando
+.idea
 *.out
 *~
-

--- a/main.go
+++ b/main.go
@@ -43,9 +43,14 @@ func main() {
 		color.Magenta("on hosts")
 		color.Yellow(fmt.Sprintf("%v", hosts))
 
-		pswd, err := prompt(args)
-		if err != nil {
-			dief("failed to read password: %v", err)
+		var pswd string
+		for _, script := range scripts {
+			if script.sudo {
+				pswd, err = prompt(args)
+				if err != nil {
+					dief("failed to read password: %v", err)
+				}
+			}
 		}
 
 		if err := run(args.user, pswd, hosts, scripts); err != nil {

--- a/scripts.go
+++ b/scripts.go
@@ -76,7 +76,7 @@ func parse(name, content string) (scriptfile, error) {
 
 	for _, part := range parts {
 		if strings.Contains(part, "PASSWORD") {
-			scriptfile.sudo = true
+			scriptFile.sudo = true
 		}
 		lines := cleanup(strings.Split(part, "\n"))
 		if len(lines) == 0 {

--- a/scripts_test.go
+++ b/scripts_test.go
@@ -54,7 +54,7 @@ PASSWORD
 # comment 4
 `
 
-func Test_parseScript(t *testing.T) {
+func Test_parseScriptWithSudo(t *testing.T) {
 	tests := []struct {
 		content    string
 		name       string
@@ -123,6 +123,75 @@ func Test_parseScript(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, test.name, scriptFile.name)
 		require.Equal(t, len(test.expScripts), len(scriptFile.scripts))
+		require.True(t, scriptFile.sudo, "Failed to parse whether or not we need a password")
+		for i := 0; i < len(test.expScripts); i++ {
+			expScript := test.expScripts[i]
+			script := scriptFile.scripts[i]
+			require.Equal(t, expScript.command, script.command)
+			require.Equal(t, len(expScript.stdin), len(script.stdin))
+			for j := 0; j < len(expScript.stdin); j++ {
+				require.Equal(t, expScript.stdin[j], script.stdin[j])
+			}
+		}
+	}
+}
+
+const file5 = `
+whoami
+`
+
+const file6 = `
+echo alpha
+---
+whoami
+---
+echo beta
+bar
+whatup
+`
+
+func Test_parseScriptWithoutSudo(t *testing.T) {
+	tests := []struct {
+		content    string
+		name       string
+		expScripts []script
+	}{
+		{
+			content: file5,
+			name:    "1-script5-no-sudo",
+			expScripts: []script{
+				{
+					command: "whoami",
+					stdin:   []string{},
+				},
+			},
+		},
+		{
+			content: file6,
+			name:    "2-script6-no-sudo",
+			expScripts: []script{
+				{
+					command: "echo alpha",
+					stdin:   []string{},
+				},
+				{
+					command: "whoami",
+					stdin:   []string{},
+				},
+				{
+					command: "echo beta",
+					stdin:   []string{"bar", "whatup"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		scriptFile, err := parse(test.name, test.content)
+		require.NoError(t, err)
+		require.Equal(t, test.name, scriptFile.name)
+		require.Equal(t, len(test.expScripts), len(scriptFile.scripts))
+		require.False(t, scriptFile.sudo, "%q %q %q", scriptFile.scripts, scriptFile.sudo, test.name)
 		for i := 0; i < len(test.expScripts); i++ {
 			expScript := test.expScripts[i]
 			script := scriptFile.scripts[i]


### PR DESCRIPTION
Because scripts need to define their stdin we're detecting it based on
whether or not the keyword we're using for password replacement is
included in the script, "PASSWORD"

For commands we're looking for the word "sudo" in the command.